### PR TITLE
Include version information in tcld builds and verify version in brew test

### DIFF
--- a/Formula/tcld.rb
+++ b/Formula/tcld.rb
@@ -1,23 +1,32 @@
 class Tcld < Formula
   desc "Temporal Cloud CLI (tcld)"
   homepage "https://temporal.io/"
-  url "https://github.com/temporalio/tcld/archive/refs/tags/v0.13.0.tar.gz"
-  sha256 "6a7c298cc7dbe7c025e1ddd06b493d41f338d403232d504d2cdde35e06c9d07e"
+  url "https://github.com/temporalio/tcld.git",
+    tag: "v0.13.1-embed-version",
+    revision: "de00ea1f0ce38f9626fc7c94d928101ee21d3665"
 
   license "MIT"
 
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"tcld", "./cmd/tcld/main.go", "./cmd/tcld/fx.go"
+    ldflags = %W[
+      -s -w
+      -X github.com/temporalio/tcld/app.version=v#{version}
+      -X github.com/temporalio/tcld/app.commit=#{Utils.git_short_head(length: 12)}
+      -X github.com/temporalio/tcld/app.date=#{time.iso8601}
+    ]
+
+    system "go", "build", *std_go_args(ldflags: ldflags), "-o", bin/"tcld", "./cmd/tcld"
   end
 
   test do
-    # Given tcld is pointless without a server, not much intersting to test here.
+    # Verify the version string and commit hash of tcld is set correctly.
     run_output = shell_output("#{bin}/tcld version 2>&1")
-    assert_match "Version", run_output
+    assert_match "v#{version}", run_output
 
-    run_output = shell_output("#{bin}/tcld -s localhost:1234 n l 2>&1")
-    assert_match "rpc error", run_output
+    # Basic validation of help.
+    run_output = shell_output("#{bin}/tcld help")
+    assert_match "tcld", run_output
   end
 end

--- a/Formula/tcld.rb
+++ b/Formula/tcld.rb
@@ -2,8 +2,8 @@ class Tcld < Formula
   desc "Temporal Cloud CLI (tcld)"
   homepage "https://temporal.io/"
   url "https://github.com/temporalio/tcld.git",
-    tag: "v0.13.1-embed-version",
-    revision: "de00ea1f0ce38f9626fc7c94d928101ee21d3665"
+    tag: "v0.13.0",
+    revision: "31a8f16fbf35094deee6af3cee2e74538055da84"
 
   license "MIT"
 

--- a/Formula/tcld.rb
+++ b/Formula/tcld.rb
@@ -21,7 +21,7 @@ class Tcld < Formula
   end
 
   test do
-    # Verify the version string and commit hash of tcld is set correctly.
+    # Verify the version string of tcld is set correctly.
     run_output = shell_output("#{bin}/tcld version 2>&1")
     assert_match "v#{version}", run_output
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This includes version information in tcld builds and modifies the tests to:
- Verify the version string is as expected from `tcld version`.
- Remove connecting to localhost and instead print a help message, as a user's machine might be running something on the specified port.

## Why?
<!-- Tell your future self why have you made these changes -->
Removes the need for us to manually bump tcld versions.

## Checklist
- [x] Ran `brew install --build-from-source ./Formula/tcld.rb` with the https://github.com/temporalio/tcld/pull/237 branch and verified the version was set correctly.
- [x] Ran `brew test ./Formula/tcld.rb` to verify the tests pass.