### PR TITLE
update tcld to v0.27.0

### DIFF
--- a/Formula/tcld.rb
+++ b/Formula/tcld.rb
@@ -2,7 +2,7 @@ class Tcld < Formula
   desc "Temporal Cloud CLI (tcld)"
   homepage "https://temporal.io/"
   url "https://github.com/temporalio/tcld.git",
-     tag: "v0.27.0"
+     tag: "v0.27.0",
      revision: "72cd25913471b9907a0ac8f22a147d92a2f60a74"
 
   license "MIT"

--- a/Formula/tcld.rb
+++ b/Formula/tcld.rb
@@ -2,8 +2,8 @@ class Tcld < Formula
   desc "Temporal Cloud CLI (tcld)"
   homepage "https://temporal.io/"
   url "https://github.com/temporalio/tcld.git",
-     tag: "v0.26.0",
-     revision: "7129c54ac08fafe6650b8f87bb2c7de70595e554"
+     tag: "v0.27.0"
+     revision: "72cd25913471b9907a0ac8f22a147d92a2f60a74"
 
   license "MIT"
 


### PR DESCRIPTION
Release: https://github.com/temporalio/tcld/releases/tag/v0.27.0.